### PR TITLE
Fixing a resource leak in move assignment

### DIFF
--- a/include/boost/coroutine2/detail/pull_coroutine.hpp
+++ b/include/boost/coroutine2/detail/pull_coroutine.hpp
@@ -56,7 +56,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 
@@ -167,7 +167,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 
@@ -276,7 +276,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 

--- a/include/boost/coroutine2/detail/pull_coroutine.hpp
+++ b/include/boost/coroutine2/detail/pull_coroutine.hpp
@@ -56,8 +56,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 

--- a/include/boost/coroutine2/detail/pull_coroutine.hpp
+++ b/include/boost/coroutine2/detail/pull_coroutine.hpp
@@ -167,8 +167,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 
@@ -277,8 +276,7 @@ public:
 
     pull_coroutine & operator=( pull_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 

--- a/include/boost/coroutine2/detail/push_coroutine.hpp
+++ b/include/boost/coroutine2/detail/push_coroutine.hpp
@@ -133,8 +133,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 
@@ -211,8 +210,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 

--- a/include/boost/coroutine2/detail/push_coroutine.hpp
+++ b/include/boost/coroutine2/detail/push_coroutine.hpp
@@ -54,8 +54,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        cb_ = other.cb_;
-        other.cb_ = nullptr;
+        std::swap(cb_, other.cb_);
         return * this;
     }
 

--- a/include/boost/coroutine2/detail/push_coroutine.hpp
+++ b/include/boost/coroutine2/detail/push_coroutine.hpp
@@ -54,7 +54,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 
@@ -133,7 +133,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 
@@ -210,7 +210,7 @@ public:
 
     push_coroutine & operator=( push_coroutine && other) noexcept {
         if ( this == & other) return * this;
-        std::swap(cb_, other.cb_);
+        std::swap( cb_, other.cb_);
         return * this;
     }
 


### PR DESCRIPTION
When a coroutine is move assigned to another coroutine, control block of source is set to nullptr. 
This results in a leak (in order of kilobytes/megabytes depending on the stack size) when the moved temporary is destructed, the destructor not invoking the deallocate() method as the control block is nullptr.

This fix attempts to solve the issue by swapping the control blocks, and as the rvalue's destructor is called, the resources are freed.