### PR TITLE
Inheriting std::iterator is deprecated in C++17

### DIFF
--- a/include/boost/coroutine2/detail/pull_coroutine.hpp
+++ b/include/boost/coroutine2/detail/pull_coroutine.hpp
@@ -68,7 +68,7 @@ public:
 
     T get() noexcept;
 
-    class iterator : public std::iterator< std::input_iterator_tag, typename std::remove_reference< T >::type > {
+    class iterator {
     private:
         pull_coroutine< T > *   c_{ nullptr };
 
@@ -88,8 +88,14 @@ public:
         }
 
     public:
-        typedef typename iterator::pointer pointer_t;
-        typedef typename iterator::reference reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef typename std::remove_reference< T >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         iterator() noexcept = default;
 
@@ -179,7 +185,7 @@ public:
 
     T & get() noexcept;
 
-    class iterator : public std::iterator< std::input_iterator_tag, typename std::remove_reference< T >::type > {
+    class iterator {
     private:
         pull_coroutine< T & > *   c_{ nullptr };
 
@@ -199,8 +205,14 @@ public:
         }
 
     public:
-        typedef typename iterator::pointer pointer_t;
-        typedef typename iterator::reference reference_t;
+        typedef std::input_iterator_tag iterator_category;
+        typedef typename std::remove_reference< T >::type value_type;
+        typedef std::ptrdiff_t difference_type;
+        typedef value_type * pointer;
+        typedef value_type & reference;
+
+        typedef pointer   pointer_t;
+        typedef reference reference_t;
 
         iterator() noexcept = default;
 

--- a/include/boost/coroutine2/detail/push_coroutine.hpp
+++ b/include/boost/coroutine2/detail/push_coroutine.hpp
@@ -66,11 +66,17 @@ public:
 
     bool operator!() const noexcept;
 
-    class iterator : public std::iterator< std::output_iterator_tag, void, void, void, void > {
+    class iterator {
     private:
         push_coroutine< T > *   c_{ nullptr };
 
     public:
+        typedef std::output_iterator_tag iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
+
         iterator() noexcept = default;
 
         explicit iterator( push_coroutine< T > * c) noexcept :
@@ -143,11 +149,17 @@ public:
 
     bool operator!() const noexcept;
 
-    class iterator : public std::iterator< std::output_iterator_tag, void, void, void, void > {
+    class iterator {
     private:
         push_coroutine< T & >   *   c_{ nullptr };
 
     public:
+        typedef std::output_iterator_tag iterator_category;
+        typedef void value_type;
+        typedef void difference_type;
+        typedef void pointer;
+        typedef void reference;
+
         iterator() noexcept = default;
 
         explicit iterator( push_coroutine< T & > * c) noexcept :


### PR DESCRIPTION
Therefore replace inheritance by lifting std::iterator's members into the derived class.

Signed-off-by: Daniela Engert <dani@ngrt.de>