### PR TITLE
Don't crash on pthread_cancel

### DIFF
--- a/include/boost/coroutine2/detail/config.hpp
+++ b/include/boost/coroutine2/detail/config.hpp
@@ -27,4 +27,19 @@
 # define BOOST_COROUTINES2_DECL
 #endif
 
+// __has_include is currently supported by GCC and Clang. However GCC 4.9 may have issues and
+// returns 1 for 'defined( __has_include )', while '__has_include' is actually not supported:
+// https://gcc.gnu.org/bugzilla/show_bug.cgi?id=63662
+#if defined( __has_include ) && (!defined( BOOST_GCC ) || (__GNUC__ + 0) >= 5)
+# if __has_include(<cxxabi.h>)
+#  define BOOST_COROUTINES2_HAS_CXXABI_H
+# endif
+#elif defined( __GLIBCXX__ ) || defined( __GLIBCPP__ )
+# define BOOST_COROUTINES2_HAS_CXXABI_H
+#endif
+
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+# include <cxxabi.h>
+#endif
+
 #endif // BOOST_COROUTINES2_DETAIL_CONFIG_H

--- a/include/boost/coroutine2/detail/pull_control_block_cc.ipp
+++ b/include/boost/coroutine2/detail/pull_control_block_cc.ipp
@@ -59,6 +59,10 @@ pull_coroutine< T >::control_block::control_block( context::preallocated palloc,
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -84,6 +88,10 @@ pull_coroutine< T >::control_block::control_block( context::preallocated palloc,
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();
@@ -207,6 +215,10 @@ pull_coroutine< T & >::control_block::control_block( context::preallocated pallo
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -232,6 +244,10 @@ pull_coroutine< T & >::control_block::control_block( context::preallocated pallo
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();
@@ -331,6 +347,10 @@ pull_coroutine< void >::control_block::control_block( context::preallocated pall
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -356,6 +376,10 @@ pull_coroutine< void >::control_block::control_block( context::preallocated pall
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();

--- a/include/boost/coroutine2/detail/push_control_block_cc.ipp
+++ b/include/boost/coroutine2/detail/push_control_block_cc.ipp
@@ -59,6 +59,10 @@ push_coroutine< T >::control_block::control_block( context::preallocated palloc,
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -86,6 +90,10 @@ push_coroutine< T >::control_block::control_block( context::preallocated palloc,
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();
@@ -182,6 +190,10 @@ push_coroutine< T & >::control_block::control_block( context::preallocated pallo
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -209,6 +221,10 @@ push_coroutine< T & >::control_block::control_block( context::preallocated pallo
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();
@@ -292,6 +308,10 @@ push_coroutine< void >::control_block::control_block( context::preallocated pall
                        fn( synthesized);
                    } catch ( boost::context::detail::forced_unwind const&) {
                        throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+                   } catch ( abi::__forced_unwind const&) {
+                       throw;
+#endif
                    } catch (...) {
                        // store other exceptions in exception-pointer
                        except = std::current_exception();
@@ -319,6 +339,10 @@ push_coroutine< void >::control_block::control_block( context::preallocated pall
                   fn( synthesized);
               } catch ( boost::context::detail::forced_unwind const&) {
                   throw;
+#if defined( BOOST_COROUTINES2_HAS_CXXABI_H )
+              } catch ( abi::__forced_unwind const&) {
+                  throw;
+#endif
               } catch (...) {
                   // store other exceptions in exception-pointer
                   except = std::current_exception();


### PR DESCRIPTION
This patch prevents `abi::__forced_unwind` from being eaten and avoids a `FATAL: exception not rethrown` error. This, however, is only part of the solution for the problem, since additional support is also needed from the context here.