### PR TITLE
Fix ambiguity of std::begin/end

### DIFF
--- a/include/boost/coroutine2/detail/pull_coroutine.hpp
+++ b/include/boost/coroutine2/detail/pull_coroutine.hpp
@@ -130,6 +130,9 @@ public:
     };
 
     friend class iterator;
+
+    iterator begin() { return iterator (this); }
+    iterator end() { return iterator(); }
 };
 
 template< typename T >
@@ -238,6 +241,9 @@ public:
     };
 
     friend class iterator;
+
+    iterator begin() { return iterator (this); }
+    iterator end() { return iterator(); }
 };
 
 template<>
@@ -278,6 +284,8 @@ public:
     explicit operator bool() const noexcept;
 
     bool operator!() const noexcept;
+
+
 };
 
 template< typename T >
@@ -293,22 +301,6 @@ end( pull_coroutine< T > &) {
 }
 
 }}}
-
-namespace std {
-
-template< typename T >
-typename boost::coroutines2::detail::pull_coroutine< T >::iterator
-begin( boost::coroutines2::detail::pull_coroutine< T > & c) {
-    return boost::coroutines2::detail::begin( c);
-}
-
-template< typename T >
-typename boost::coroutines2::detail::pull_coroutine< T >::iterator
-end( boost::coroutines2::detail::pull_coroutine< T > & c) {
-    return boost::coroutines2::detail::end( c);
-}
-
-}
 
 #ifdef BOOST_HAS_ABI_HEADERS
 #  include BOOST_ABI_SUFFIX


### PR DESCRIPTION
- this patch should restore the range-based for functionality for pull-type coroutines
fixes #39 
fixes #42