### PR TITLE
Add support for modular build structure.

### DIFF
--- a/build.jam
+++ b/build.jam
@@ -1,4 +1,4 @@
-# Copyright René Ferdinand Rivera Morell 2023
+# Copyright René Ferdinand Rivera Morell 2023-2024
 # Distributed under the Boost Software License, Version 1.0.
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)

--- a/build.jam
+++ b/build.jam
@@ -3,9 +3,7 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
-require-b2 5.1 ;
-
-import project ;
+require-b2 5.2 ;
 
 project /boost/coroutine2
     : common-requirements

--- a/build.jam
+++ b/build.jam
@@ -7,9 +7,9 @@ import project ;
 
 project /boost/coroutine2
     : common-requirements
-        <source>/boost/assert//boost_assert
-        <source>/boost/config//boost_config
-        <source>/boost/context//boost_context
+        <library>/boost/assert//boost_assert
+        <library>/boost/config//boost_config
+        <library>/boost/context//boost_context
         <include>include
     ;
 

--- a/build.jam
+++ b/build.jam
@@ -3,6 +3,8 @@
 # (See accompanying file LICENSE_1_0.txt or copy at
 # http://www.boost.org/LICENSE_1_0.txt)
 
+require-b2 5.1 ;
+
 import project ;
 
 project /boost/coroutine2

--- a/build.jam
+++ b/build.jam
@@ -1,0 +1,22 @@
+# Copyright René Ferdinand Rivera Morell 2023
+# Distributed under the Boost Software License, Version 1.0.
+# (See accompanying file LICENSE_1_0.txt or copy at
+# http://www.boost.org/LICENSE_1_0.txt)
+
+import project ;
+
+project /boost/coroutine2
+    : common-requirements
+        <source>/boost/assert//boost_assert
+        <source>/boost/config//boost_config
+        <source>/boost/context//boost_context
+        <include>include
+    ;
+
+explicit
+    [ alias boost_coroutine2 ]
+    [ alias all : boost_coroutine2 example test ]
+    ;
+
+call-if : boost-library coroutine2
+    ;

--- a/build.jam
+++ b/build.jam
@@ -5,18 +5,21 @@
 
 require-b2 5.2 ;
 
+constant boost_dependencies :
+    /boost/assert//boost_assert
+    /boost/config//boost_config
+    /boost/context//boost_context ;
+
 project /boost/coroutine2
     : common-requirements
-        <library>/boost/assert//boost_assert
-        <library>/boost/config//boost_config
-        <library>/boost/context//boost_context
         <include>include
     ;
 
 explicit
-    [ alias boost_coroutine2 ]
+    [ alias boost_coroutine2 : : : : <library>$(boost_dependencies) ]
     [ alias all : boost_coroutine2 example test ]
     ;
 
 call-if : boost-library coroutine2
     ;
+

--- a/example/Jamfile.v2
+++ b/example/Jamfile.v2
@@ -13,7 +13,7 @@ import modules ;
 import os ;
 import toolset ;
 
-project boost/coroutine2/example
+project
     : requirements
       <library>/boost/context//boost_context
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -12,6 +12,7 @@ import os ;
 import path ;
 import testing ;
 import toolset ;
+import-search /boost/config/checks ;
 import config : requires ;
 
 project
@@ -47,7 +48,7 @@ rule native-impl ( properties * )
 }
 
 test-suite minimal :
-[ run test_coroutine.cpp : 
+[ run test_coroutine.cpp :
     : :
     <context-impl>fcontext
     [ requires cxx11_auto_declarations
@@ -63,7 +64,7 @@ test-suite minimal :
                cxx11_variadic_templates ]
     : test_coroutine_asm ]
 
-[ run test_coroutine.cpp : 
+[ run test_coroutine.cpp :
     : :
     <conditional>@native-impl
     [ requires cxx11_auto_declarations

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -12,11 +12,11 @@ import os ;
 import path ;
 import testing ;
 import toolset ;
-import ../../config/checks/config : requires ;
+import config : requires ;
 
-project boost/coroutine2/test
+project
     : requirements
-      <library>../../test/build//boost_unit_test_framework
+      <library>/boost/test//boost_unit_test_framework
       <library>/boost/context//boost_context
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-fsplit-stack
       <target-os>linux,<toolset>gcc,<segmented-stacks>on:<cxxflags>-DBOOST_USE_SEGMENTED_STACKS


### PR DESCRIPTION
This is part of the effort to make the Boost libraries "modular" for build and consumption. See https://lists.boost.org/Archives/boost/2024/01/255704.php and https://github.com/grafikrobot/boost-b2-modular/blob/b2-modular/README.adoc for more information.

This PR depends on the following other PRs being merged to both develop and master branches of the respective repos:

- https://github.com/boostorg/boost/pull/854

This PR will be changed to ready for review, i.e. not draft, when the above are merged. Do not merge this one until that time.